### PR TITLE
fixed broken guide ToC links by correcting id errors

### DIFF
--- a/compmajorguide.html
+++ b/compmajorguide.html
@@ -133,7 +133,7 @@
 <li><a href="#comp-400-honours-project-in-computer-science">COMP 400: Honours project in Computer Science</a></li>
 <li><a href="#comp-401-project-in-biology-and-computer-science">COMP 401: Project in Biology and Computer Science</a></li>
 <li><a href="#comp-409-concurrent-programming">COMP 409: Concurrent Programming</a></li>
-<li><a href="#comp-417-introduction-robotics-and-intelligent-systems">COMP 417: Introduction Robotics and Intelligent Systems</a></li>
+<li><a href="#comp-417-introduction-to-robotics-and-intelligent-systems">COMP 417: Introduction Robotics and Intelligent Systems</a></li>
 <li><a href="#comp-421-database-systems">COMP 421: Database Systems</a></li>
 <li><a href="#comp-424-artificial-intelligence">COMP 424: Artificial Intelligence</a></li>
 <li><a href="#comp-462-computational-biology-methods">COMP 462: Computational Biology Methods</a></li>
@@ -854,7 +854,7 @@ I really liked the class, but I'm heavily interested in graphics. I also grew up
 </table>
 
 
-<h3 id="comp-321-programming-languages">COMP 321: Programming Challenges</h3>
+<h3 id="comp-321-programming-challenges">COMP 321: Programming Challenges</h3>
 
 <ul>
 <li><strong>1 credit</strong></li>
@@ -1140,7 +1140,7 @@ I really liked the class, but I'm heavily interested in graphics. I also grew up
 </ul>
 
 
-<h3 id="comp-424-artificial=intelligence">COMP 424: Artificial Intelligence</h3>
+<h3 id="comp-424-artificial-intelligence">COMP 424: Artificial Intelligence</h3>
 
 <ul>
 <li><strong>3 credits</strong></li>
@@ -1262,7 +1262,7 @@ I really liked the class, but I'm heavily interested in graphics. I also grew up
 </ul>
 
 
-<h3 id="comp-524-theoretical-foudnations-of-programming-languages">COMP 524: Theoretical Foundations of Programming Languages</h3>
+<h3 id="comp-524-theoretical-foundations-of-programming-languages">COMP 524: Theoretical Foundations of Programming Languages</h3>
 
 <ul>
 <li><strong>3 credits</strong></li>
@@ -1382,7 +1382,7 @@ I'd definitely recommend it if you enjoyed 330 and are interested in seeing how 
 </ul>
 
 
-<h3 id="comp-533-model-drive-software-development">COMP 533: Model-Driven Software Development</h3>
+<h3 id="comp-533-model-driven-software-development">COMP 533: Model-Driven Software Development</h3>
 
 <ul>
 <li><strong>3 credits</strong></li>
@@ -1406,7 +1406,7 @@ I'd definitely recommend it if you enjoyed 330 and are interested in seeing how 
 </ul>
 
 
-<h3 id="comp-540-matrix-computation">COMP 540: Matrix Computations</h3>
+<h3 id="comp-540-matrix-computations">COMP 540: Matrix Computations</h3>
 
 <ul>
 <li><strong>3 credits</strong></li>
@@ -1430,7 +1430,7 @@ I'd definitely recommend it if you enjoyed 330 and are interested in seeing how 
 </ul>
 
 
-<h3 id="comp547-cryptography-and-data-security">COMP 547: Cryptography and Data Security</h3>
+<h3 id="comp-547-cryptography-and-data-security">COMP 547: Cryptography and Data Security</h3>
 
 <ul>
 <li><strong>4 credits</strong></li>


### PR DESCRIPTION
See issue #13 (Computer Science Guide: broken Table of Contents links due to html id typos/errors)